### PR TITLE
build(deps): bump Go from 1.25.5 to 1.25.8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/zncdatadev/go-devel:1.25.5-kubedoop0.0.0-dev AS builder
+FROM quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/build/csiplugin.Dockerfile
+++ b/build/csiplugin.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/zncdatadev/go-devel:1.25.5-kubedoop0.0.0-dev AS builder
+FROM quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zncdatadev/listener-operator
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/container-storage-interface/spec v1.12.0


### PR DESCRIPTION
Bump Go version from 1.25.5 to 1.25.8.

- go.mod: go 1.25.8
- build/Dockerfile: quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev
- build/csiplugin.Dockerfile: quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev