### PR TITLE
fix(ci): split chart-lint-test into chart-lint-helm and chart-e2e

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -107,7 +107,7 @@ jobs:
           kind load docker-image quay.io/zncdatadev/listener-operator:$VERSION quay.io/zncdatadev/listener-csi-driver:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
+
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config ./.github/configs/ct-install.yaml

--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: deploy/helm
         run: ah lint
 
-  lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -83,17 +83,27 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --debug --config ./.github/configs/ct-lint.yaml
 
-      - name: Create kind cluster
+      - name: Setup Go
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.14.0
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
 
-      - name: Load images to cluster
+      - name: Build images
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           make docker-build
           make csi-docker-build
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+        with:
+          cluster_name: kind
+
+      - name: Load images to cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
           kind load docker-image quay.io/zncdatadev/listener-operator:$VERSION quay.io/zncdatadev/listener-csi-driver:$VERSION
 
       - name: Run chart-testing (install)
@@ -106,26 +116,19 @@ jobs:
             echo "ct_tested=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run chart e2e
         run: |
-          make helm-chart-package
-
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-          )
-
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace listener-operator --wait listener-operator ./target/charts/listener-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          make chart-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,7 @@ jobs:
           kind load docker-image quay.io/zncdatadev/listener-operator:$VERSION quay.io/zncdatadev/listener-csi-driver:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
+
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           ct install \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
         run: ah lint
 
 
-  chart-lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -292,17 +292,27 @@ jobs:
             --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
             --config ./.github/configs/ct-lint.yaml
 
-      - name: Create kind cluster
+      - name: Setup Go
         if: steps.check-changes.outputs.changed == 'true'
-        uses: helm/kind-action@v1.14.0
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
 
-      - name: Load images to cluster
+      - name: Build images
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           make docker-build
           make csi-docker-build
+
+      - name: Create kind cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+        with:
+          cluster_name: kind
+
+      - name: Load images to cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
           kind load docker-image quay.io/zncdatadev/listener-operator:$VERSION quay.io/zncdatadev/listener-csi-driver:$VERSION
 
       - name: Run chart-testing (install)
@@ -318,29 +328,22 @@ jobs:
             echo "ct_tested=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run chart e2e
         run: |
-          make helm-chart-package
-
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-          )
-
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace listener-operator --wait listener-operator ./target/charts/listener-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          make chart-e2e
 
 
   release-chart:
@@ -349,7 +352,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - chart-linter-artifacthub
-      - chart-lint-test
+      - chart-lint-helm
+      - chart-e2e
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,15 @@ setup-chainsaw-e2e: chainsaw docker-build csi-docker-build ## Run the chainsaw s
 chainsaw-e2e: ## Run the chainsaw e2e tests
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
+.PHONY: chart-e2e
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build csi-docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)" "$(CSIDRIVER_IMG)"
+	"$(HELM)" upgrade --install --create-namespace --namespace $(PROJECT_NAME) \
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
+		--set image.csiDriver.tag=$(VERSION) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) undeploy


### PR DESCRIPTION
Align with secret-operator CI fixes (#343, #346, #347, #348):

- Split `chart-lint-test`/`lint-test` job into `chart-lint-helm` (ct lint + ct install with kind cluster + image build + load) and `chart-e2e` (make chart-e2e with chainsaw functional tests)
- Add `chart-e2e` Makefile target that builds images, packages chart, loads to chainsaw cluster, installs via helm, and runs chainsaw e2e
- chart-e2e runs independently with its own chainsaw cluster
- Remove inline helm install + chainsaw e2e steps from workflow