### PR TITLE
docs: update release guide to match actual CI workflow jobs

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -113,7 +113,8 @@ runs the following jobs:
   (1.33, 1.34, 1.35)
 - **CRD Sync Check** — Verifies CRDs are in sync with manifests
 - **Chart Linter (Artifact Hub)** — Validates Helm chart metadata
-- **Chart Lint & Test** — Validates and tests the Helm chart
+- **Chart Lint Helm** — Validates the Helm chart with ct lint and installs it with ct install
+- **Chart E2E** — Runs Chainsaw E2E tests against a Helm-installed release
 - **Release Image** — Builds and pushes multi-arch Docker images to
   `quay.io/zncdatadev/listener-operator:<version>` and
   `quay.io/zncdatadev/listener-csi-driver:<version>`, and signs the images with
@@ -165,7 +166,7 @@ git push upstream 0.4.0
 
 ### Chart release failed
 
-If the `chart-lint-test` or `release-chart` job fails, check the workflow logs
+If the `chart-lint-helm` or `release-chart` job fails, check the workflow logs
 for details. Common issues include:
 
 - **CRDs out of sync**: Run `make manifests` and `make helm-crd-sync` to

--- a/docs/release.md
+++ b/docs/release.md
@@ -110,7 +110,6 @@ runs the following jobs:
 - **Golang Lint** — Runs golangci-lint
 - **Golang Test** — Runs unit tests
 - **Chainsaw Test** — Runs Chainsaw E2E tests across multiple Kubernetes versions
-  (1.33, 1.34, 1.35)
 - **CRD Sync Check** — Verifies CRDs are in sync with manifests
 - **Chart Linter (Artifact Hub)** — Validates Helm chart metadata
 - **Chart Lint Helm** — Validates the Helm chart with `ct lint` and installs it with `ct install`

--- a/docs/release.md
+++ b/docs/release.md
@@ -113,7 +113,7 @@ runs the following jobs:
   (1.33, 1.34, 1.35)
 - **CRD Sync Check** — Verifies CRDs are in sync with manifests
 - **Chart Linter (Artifact Hub)** — Validates Helm chart metadata
-- **Chart Lint Helm** — Validates the Helm chart with ct lint and installs it with ct install
+- **Chart Lint Helm** — Validates the Helm chart with `ct lint` and installs it with `ct install`
 - **Chart E2E** — Runs Chainsaw E2E tests against a Helm-installed release
 - **Release Image** — Builds and pushes multi-arch Docker images to
   `quay.io/zncdatadev/listener-operator:<version>` and


### PR DESCRIPTION
## Summary

- Split `Chart Lint & Test` into two separate jobs matching the actual workflow:
  - **Chart Lint Helm** — ct lint + ct install
  - **Chart E2E** — Chainsaw E2E tests against Helm-installed release
- Updated `chart-lint-test` reference in troubleshooting to `chart-lint-helm`
- listener-operator does not have a standalone E2E Test job (only Chainsaw Test)

## Files Changed

- `docs/release.md`